### PR TITLE
Support for all 8 curses colors

### DIFF
--- a/culour/culour.py
+++ b/culour/culour.py
@@ -5,21 +5,27 @@ COLOR_PAIRS_CACHE = {}
 
 
 class TerminalColors(object):
+    WHITE = '[97'
+    CYAN = '[96'
     MAGENTA = '[95'
     BLUE = '[94'
-    GREEN = '[92'
     YELLOW = '[93'
+    GREEN = '[92'
     RED = '[91'
+    BLACK = '[90'
     END = '[0'
 
 
 # Translates between the terminal notation of a color, to it's curses color number
 TERMINAL_COLOR_TO_CURSES = {
+    TerminalColors.BLACK: curses.COLOR_BLACK,
     TerminalColors.RED: curses.COLOR_RED,
     TerminalColors.GREEN: curses.COLOR_GREEN,
     TerminalColors.YELLOW: curses.COLOR_YELLOW,
     TerminalColors.BLUE: curses.COLOR_BLUE,
-    TerminalColors.MAGENTA: curses.COLOR_MAGENTA
+    TerminalColors.MAGENTA: curses.COLOR_MAGENTA,
+    TerminalColors.CYAN: curses.COLOR_CYAN,
+    TerminalColors.WHITE: curses.COLOR_WHITE
 }
 
 

--- a/test.py
+++ b/test.py
@@ -3,23 +3,29 @@
 import curses
 import culour
 
-
-class COLORS(object):
-    MAGENTA = '\033[95m'
-    BLUE = '\033[94m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    RED = '\033[91m'
-    END = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-
-
 def test(stdscr):
-    string = "white{red}red{end}\nwhite{green}green{end}white".format(red=COLORS.RED,
-                                                                      green=COLORS.GREEN,
-                                                                      end=COLORS.END)
-    culour.addstr(stdscr, 10, 50, string)
+    # Create a string with all colors
+    string = ("default "
+              "{black}black{end} "
+              "{red}red{end} "
+              "{green}green{end} "
+              "{yellow}yellow{end} "
+              "{blue}blue{end} "
+              "{magenta}magenta{end} "
+              "{cyan}cyan{end} "
+              "{white}white{end} "
+              "default").format(black='\033[90m',
+                              red='\033[91m',
+                              green='\033[92m',
+                              yellow='\033[93m',
+                              blue='\033[94m',
+                              magenta='\033[95m',
+                              cyan='\033[96m',
+                              white='\033[97m',
+                              end='\033[0m')
+
+    # Add the string to the curses window
+    culour.addstr(stdscr, 10, 10, string)
     stdscr.getch()
 
 curses.wrapper(test)


### PR DESCRIPTION
Implemented support for all 8 curses colors, namely:
```python
class TerminalColors(object):
    WHITE = '[97'
    CYAN = '[96'
    MAGENTA = '[95'
    BLUE = '[94'
    YELLOW = '[93'
    GREEN = '[92'
    RED = '[91'
    BLACK = '[90'
    END = '[0'
```

Updated `test.py` to test all colors.