### PR TITLE
fix rst code blocks to display correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,27 +9,33 @@ Print colored strings in curses windows easily
 The problem
 -----------
 There's no way to print pre-formatted, colored terminal text into curses.
-If you're printing '\033[94m Blue', which in regular bash terminal is a nice-blue text,
-in curses, it will be printed as '^[[94m Blue'
+If you're printing ``\033[94m Blue``, which in regular bash terminal is a nice-blue text,
+in curses, it will be printed as ``^[[94m Blue``
 
 Solution
 --------
 Use culour (pronounced 'cooler') to print the colored strings onto your curses window.
 Instead of using:
-```python
-window.addstr("colored string")
-```
-Simply use;
-```python
-import culour
-culour.addstr(window, "colored string")
-```
+
+.. code:: python
+
+	window.addstr("colored string")
+
+Simply use:
+
+.. code:: python
+
+	import culour
+	culour.addstr(window, "colored string")
+
 
 And your string will be added to the screen nice and colored.
 
 To print to a specific place in the screen, use:
-```python
-culour.addstr(window, y, x, "colored string")
-```
 
-Don't forget to initialize the color usage in your curses window by calling ```curses.start_color()``` immediately after ```curses.initscr()```
+.. code:: python
+
+	culour.addstr(window, y, x, "colored string")
+
+
+Don't forget to initialize the color usage in your curses window by calling ``curses.start_color()`` immediately after ``curses.initscr()``


### PR DESCRIPTION
fix rst code blocks to display correctly; code blocks were using md syntax which doesn't work in rst